### PR TITLE
Update readme for adoption of respondable.next

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # respondable
 
-A small utility that accepts an object and a callback. The object contains media query descriptions and corresponding return values. The callback is invoked when a query becomes active or innactive and upon initialization. The callback will recieve all of the values associated with active mediaqueries.
+A small utility that makes dealing with media queries programmatically a breeze. `respondable` accepts an object with media query configuration(s) and a callback. The callback will trigger whenever a media query becomes inactive or active, and will have all active media queries passed in.
 
 respondable doesn't use any `resize` event handlers. Instead it relies on the `addListener` method of the `MediaQueryList` object returned by `matchMedia` (see [docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia)).
 
@@ -21,21 +21,19 @@ respondable doesn't use any `resize` event handlers. Instead it relies on the `a
 `$ npm install --save respondable`
 
 ## Changelog
-> `respondable.next` has been exposed and will take the place of `respondable` in the next release.
+> Instead of returning an ID that needs to be passed into `respondable.destroy`, `respondable` will return a `destroy` function that is already bound to your respondable instance. See the example [below](#example).
 
 > Support for default value as a property of the `breakpoints` object has been deprecated. (See Best Practices for more details.)
 
-> Respondable had been passing the value of a single query into the callback when multiple queries matched. Now an array of all matching values will be passed in to the callback.
+> In the previous version, respondable had been passing the value of a single query into the callback when multiple queries matched. Now an array of all matching values will be passed in to the callback.
 
 ## Documentation
 
-### respondable.next
-> `respondable.next` is the recommended implementation of respondable. It will be available as `respondable` in the next release.
-
+### respondable
 - Parameters: `breakpoints` and  `callback`
 - Returns: `destroy`, a function that will remove registered listeners when invoked.
 
-Creates a MediaQueryObjectList for each media query in `breakpoints`. A query becoming active or innactive will invoke `callback`. The callback will also be invoked upon initialization. Callback will recieve all of the values associated with the active mediaqueries.
+Creates a MediaQueryObjectList for each media query in `breakpoints`. A query becoming active or inactive will invoke `callback`. The callback will also be invoked upon initialization. Callback will recieve all of the values associated with the active media queries.
 
 #### breakpoints <object>
 
@@ -46,7 +44,7 @@ Creates a MediaQueryObjectList for each media query in `breakpoints`. A query be
 
 - Parameter: `values`
 
-Invoked when a query becomes active or innactive and also when the instance is first initialized. `values` is of type Array and populated with each value (from `breakpoints`) corresponding to a matching query (from `breakpoints`).
+Invoked when a query becomes active or inactive and also when the instance is first initialized. `values` is of type Array and populated with each value (from `breakpoints`) corresponding to a matching query (from `breakpoints`).
 
 ###### Example:
 ```js
@@ -58,49 +56,12 @@ const breakpointObject = {
   'screen and (min-width: 1400px)': 'largest',
 };
 
-const destroy = respondable.next(map, function(values) {
+const destroy = respondable(map, function(values) {
   // use value here
 });
 
 // remove registered listeners
 destroy();
-```
-
-**Benefits of `respondable.next`**
-- `Respondable.next` does not have package level state, instances are not aware of eachother. (Doesn't affect consumer.)
-- No need for the `respondable.destroy` method
-
-### respondable <function>
-
-- Parameters: `breakpoints` and  `callback` (as seen in `respondable.next`)
-- Returns: `id` of type number. Must be passed into `respondable.destroy` in order to remove listeners.
-
-Creates a MediaQueryObjectList for each media query specified in `breakpoints`.
-A change in the state of a query will invoke `callback`, passing in all currently matching values.
-
-### respondable.destroy <function>
-
-- Has one parameter: `id` of type number.
-- Returns true if deregistration was successful, false otherwise.
-
-If passed a valid id, will remove all registered the MediaQueryList listeners.
-
-###### Example:
-```js
-const breakpointObject = {
-  'screen and (max-width: 413px)': 'smallest',
-  'screen and (min-width: 414px) and (max-width: 767px)': 'small',
-  'screen and (min-width: 768px) and (max-width: 1079px)': 'medium',
-  'screen and (min-width: 1080px) and (max-width: 1399px)': 'large',
-  'screen and (min-width: 1400px)': 'largest',
-};
-
-const respondableID = respondable(map, function(values) {
-  // use value here
-});
-
-// remove registered listeners
-respondable.destroy(respondableID);
 ```
 
 ## Best practices


### PR DESCRIPTION
Forgot to do these updates in the last PR (oops)
- No longer refer to the current respondable implementation as respondable.next.
- First line now states the purpose of the package.
- Minor spelling / grammar fixes.
